### PR TITLE
Fix Supabase auth module exports

### DIFF
--- a/public/supabase-auth.js
+++ b/public/supabase-auth.js
@@ -402,3 +402,9 @@ const ApiClient = {
 if (typeof module !== 'undefined' && module.exports) {
     module.exports = { SupabaseAuth, ApiClient };
 }
+
+// Expose to browser global scope
+if (typeof window !== 'undefined') {
+    window.SupabaseAuth = SupabaseAuth;
+    window.ApiClient = ApiClient;
+}


### PR DESCRIPTION
## Summary
- Expose SupabaseAuth and ApiClient to the browser global scope

## Testing
- `npm test` *(fails: no test specified)*


------
https://chatgpt.com/codex/tasks/task_e_6898fd4e53e8832a8471e4f73f88339b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Made SupabaseAuth and ApiClient available globally in the browser, allowing direct access from the browser's JavaScript console or scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->